### PR TITLE
Avoid O(n^2) copy operations when draining the Q

### DIFF
--- a/promise.lua
+++ b/promise.lua
@@ -142,11 +142,8 @@ run = function(promise)
   if promise.state == State.PENDING then return end
 
   do_async(function()
-    while true do
-      local obj = table.remove(promise.queue, 1)
-      if not obj then
-        break
-      end
+    for i, obj in ipairs(promise.queue) do
+      promise.queue[i] = nil
 
       local success, result = pcall(function()
         local success = obj.fulfill or passthrough


### PR DESCRIPTION
Using `table.remove(q, 1)` will shift the remaining elements down causing #q - 1 copy operations.
This should be avoided.

Special care has to be taken since we are executing callbacks within the loop that potentially (?!) push further elements to the queue.